### PR TITLE
Add new native `rg_observer_find_next_player`

### DIFF
--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll.inc
@@ -1186,6 +1186,18 @@ native rg_disappear(const player);
 native rg_set_observer_mode(const player, const mode);
 
 /*
+* Call origin function CBasePlayer::Observer_FindNextPlayer()
+* @note Player must be a valid observer (m_afPhysicsFlags & PFLAG_OBSERVER).
+*
+* @param player                Player index.
+* @param bReverse              If bReverse is true, finding order will be reversed
+* @param name                  Player name to find.
+*
+* @noreturn
+*/
+native rg_observer_find_next_player(const player, const bool:bReverse = false, const name[] = "");
+
+/*
 * Emits a death notice (logs, DeathMsg event, win conditions check)
 *
 * @param pVictim               Player index.

--- a/reapi/include/cssdk/dlls/API/CSPlayer.h
+++ b/reapi/include/cssdk/dlls/API/CSPlayer.h
@@ -94,6 +94,7 @@ public:
 	virtual void SendItemStatus() = 0;
 	virtual void ReloadWeapons(CBasePlayerItem *pWeapon = nullptr, bool bForceReload = false, bool bForceRefill = false) = 0;
 	virtual void Observer_SetMode(int iMode) = 0;
+	virtual void Observer_FindNextPlayer(bool bReverse, const char *name = nullptr) = 0;
 	virtual bool SelectSpawnSpot(const char *pEntClassName, CBaseEntity* &pSpot) = 0;
 	virtual bool SwitchWeapon(CBasePlayerItem *pWeapon) = 0;
 	virtual void SwitchTeam() = 0;

--- a/reapi/src/natives/natives_misc.cpp
+++ b/reapi/src/natives/natives_misc.cpp
@@ -3243,6 +3243,34 @@ cell AMX_NATIVE_CALL rg_set_observer_mode(AMX* amx, cell* params)
 }
 
 /*
+* Call origin function CBasePlayer::Observer_FindNextPlayer()
+* @note Player must be a valid observer (m_afPhysicsFlags & PFLAG_OBSERVER).
+*
+* @param player                Player index.
+* @param bReverse              If bReverse is true, finding order will be reversed
+* @param name                  Player name to find.
+*
+* @noreturn
+*/
+cell AMX_NATIVE_CALL rg_observer_find_next_player(AMX* amx, cell* params)
+{
+	enum args_e { arg_count, arg_index, arg_bReverse, arg_name };
+
+	CHECK_ISPLAYER(arg_index)
+
+	CBasePlayer *pPlayer = UTIL_PlayerByIndex(params[arg_index]);
+	CHECK_CONNECTED(pPlayer, arg_index);
+
+	char nameBuf[MAX_PLAYER_NAME_LENGTH];
+	const char* name = getAmxString(amx, params[arg_name], nameBuf);
+	if (strcmp(name, "") == 0)
+		name = nullptr;
+
+	pPlayer->CSPlayer()->Observer_FindNextPlayer(params[arg_bReverse] != 0, name);
+	return TRUE;
+}
+
+/*
 * Emits a death notice (logs, DeathMsg event, win conditions check)
 *
 * @param pVictim               Player index.
@@ -3455,6 +3483,7 @@ AMX_NATIVE_INFO Misc_Natives_RG[] =
 	{ "rg_switch_best_weapon",        rg_switch_best_weapon        },
 	{ "rg_disappear",                 rg_disappear                 },
 	{ "rg_set_observer_mode",         rg_set_observer_mode         },
+	{ "rg_observer_find_next_player", rg_observer_find_next_player },
 	{ "rg_death_notice",              rg_death_notice              },
 	{ "rg_player_relationship",       rg_player_relationship       },
 


### PR DESCRIPTION
Tested✔

```cpp
#include <amxmodx>
#include <reapi>

public plugin_init()
{
    register_clcmd("say .fnp", "cmd_fnp");

    RegisterHookChain(RG_CBasePlayer_Observer_FindNextPlayer, "RG_CBasePlayer_Observer_FindNextPlayer_Pre", false);
}

public RG_CBasePlayer_Observer_FindNextPlayer_Pre(const this, bool:bReverse, name[])
{
    client_print(this, print_chat, "FindNextPlayer: bReverse(%d), name(%s)", bReverse, name);
}

public cmd_fnp(const index)
{
    if (!(get_member(index, m_afPhysicsFlags) & PFLAG_OBSERVER))
    {
        client_print(index, print_chat, "YOUR ARE NOT A OBSERVER");
        return PLUGIN_HANDLED;
    }

    client_print(index, print_chat, "YOU DID");
    rg_observer_find_next_player(index, true, "");
    return PLUGIN_HANDLED;
}

```