### PR TITLE
Fix archive signing to use correct version variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
           
           # Pack and sign final archive
           7z a -tzip reapi-bin-${{ needs.linux.outputs.app-version }}.zip addons/
-          sign_file "reapi-bin-${{ env.APP_VERSION }}.zip"
+          sign_file "reapi-bin-${{ needs.linux.outputs.app-version }}.zip"
 
       - name: Publish artifacts
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Previously, the sign_file command used env.APP_VERSION, which could be inconsistent with the archive filename generated using needs.linux.outputs.app-version.
This commit ensures both use the same version source (needs.linux.outputs.app-version) to avoid mismatches and signing errors.